### PR TITLE
Add a type declaration file

### DIFF
--- a/lib/canonicalize.d.ts
+++ b/lib/canonicalize.d.ts
@@ -1,0 +1,1 @@
+export default function serialize(input: unknown): string | undefined;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.3",
   "description": "JSON canonicalize function ",
   "main": "lib/canonicalize.js",
+  "types": "lib/canonicalize.d.ts",
   "directories": {
     "example": "examples",
     "lib": "lib"


### PR DESCRIPTION
This way, TypeScript consumers of the package can enjoy type-checking
without having to define the types in their project.