### PR TITLE
Add check for whether Unicode is valid and well-formed

### DIFF
--- a/lib/canonicalize.js
+++ b/lib/canonicalize.js
@@ -11,6 +11,10 @@ module.exports = function serialize (object) {
     throw new Error('Infinity is not allowed');
   }
 
+  if (typeof object === 'string' && !isWellFormed(object)) {
+    throw new Error('Strings must be valid Unicode and not contain any surrogate pairs');
+  }
+
   if (object === null || typeof object !== 'object') {
     return JSON.stringify(object);
   }
@@ -38,3 +42,21 @@ module.exports = function serialize (object) {
   }, '');
   return `{${values}}`;
 };
+
+function isWellFormed (str) {
+  if (typeof String.prototype.isWellFormed === 'function') {
+    return str.isWellFormed();
+  }
+
+  // https://github.com/tc39/proposal-is-usv-string
+  // https://github.com/zloirock/core-js/blob/d6ad38c/packages/core-js/modules/esnext.string.is-well-formed.js
+  const length = str.length;
+  for (let i = 0; i < length; i++) {
+    const charCode = str.charCodeAt(i);
+    // single UTF-16 code unit
+    if ((charCode & 0xF800) !== 0xD800) continue;
+    // unpaired surrogate
+    if (charCode >= 0xDC00 || ++i >= length || (str.charCodeAt(i) & 0xFC00) !== 0xDC00) return false;
+  }
+  return true;
+}

--- a/lib/canonicalize.js
+++ b/lib/canonicalize.js
@@ -43,20 +43,12 @@ module.exports = function serialize (object) {
   return `{${values}}`;
 };
 
+const stringSurrogateRegex = /\p{Surrogate}/u;
+
 function isWellFormed (str) {
   if (typeof String.prototype.isWellFormed === 'function') {
     return str.isWellFormed();
   }
 
-  // https://github.com/tc39/proposal-is-usv-string
-  // https://github.com/zloirock/core-js/blob/d6ad38c/packages/core-js/modules/esnext.string.is-well-formed.js
-  const length = str.length;
-  for (let i = 0; i < length; i++) {
-    const charCode = str.charCodeAt(i);
-    // single UTF-16 code unit
-    if ((charCode & 0xF800) !== 0xD800) continue;
-    // unpaired surrogate
-    if (charCode >= 0xDC00 || ++i >= length || (str.charCodeAt(i) & 0xFC00) !== 0xDC00) return false;
-  }
-  return true;
+  return !stringSurrogateRegex.test(str);
 }

--- a/test/simpletests.js
+++ b/test/simpletests.js
@@ -198,3 +198,14 @@ test('object with toJSON', t => {
   const actual = JSON.canonicalize(input);
   t.is(actual, expected);
 });
+
+test('"lone surrogate" invalid Unicode data', t => {
+  const input = { test: '\u{DEAD}' };
+  try {
+    console.log(JSON.canonicalize(input));
+    t.fail();
+  } catch (error) {
+    t.is(error.message, 'Strings must be valid Unicode and not contain any surrogate pairs');
+    t.pass();
+  }
+});


### PR DESCRIPTION
Hi, was looking for a way to canonicalize JSON, thanks for the module. :cat: 

I noticed there wasn't anything to handle the following section in RFC8785:

> Note: Since invalid Unicode data like "lone surrogates" (e.g., U+DEAD) may lead to interoperability issues including broken signatures, occurrences of such data MUST cause a compliant JCS implementation to terminate with an appropriate error.

This should fix that.