### PR TITLE
Allow running as CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ const  json = {
 console.log(canonicalize(json));
 // output: {"":"empty","1":{"\n":56,"f":{"F":5,"f":"hi"}},"10":{},"111":[{"E":"no","e":"yes"}],"A":{},"a":{}}
 ```
+### Via CLI
+The function can be executed directly using npx without explicit installation. This allows JSON files and arbitrary input to be canonicalized with standard input/output:
+```bash
+# Input from file
+npx canonicalize < input.json > output.json
+
+# Input from string
+echo '{
+	"from_account": "543 232 625-3",
+	"to_account": "321 567 636-4",
+	"amount": 500,
+	"currency": "USD"
+}' | npx canonicalize > simple-data.json
+
+# Input from web API
+curl --silent https://pokeapi.co/api/v2/pokemon/pikachu | npx canonicalize > pikachu.json
+```
 ## Install
 ```
 npm install canonicalize --save

--- a/bin/canonicalize.js
+++ b/bin/canonicalize.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const canonicalize = require('../');
+
+let input = '';
+
+process.stdin
+  .on('data', (data) => input += data.toString())
+  .on('end', () => {
+    const output = canonicalize(JSON.parse(input));
+    process.stdout.write(output, 'utf-8');
+  });

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "JSON canonicalize function ",
   "main": "lib/canonicalize.js",
   "types": "lib/canonicalize.d.ts",
+  "bin": "bin/canonicalize.js",
   "directories": {
     "example": "examples",
     "lib": "lib"


### PR DESCRIPTION
The changes in this pull request add an executable version of the library so that it can be executed using `npx` (or `node --run` in recent versions of Node.js).

This allows it to be used directly on the command line without having to install it and write a small script. See example usages in amended README file.