### PR TITLE
Fix types to match JavaScript export

### DIFF
--- a/lib/canonicalize.d.ts
+++ b/lib/canonicalize.d.ts
@@ -1,1 +1,2 @@
-export default function serialize(input: unknown): string | undefined;
+declare function serialize(input: unknown): string | undefined;
+export = serialize;


### PR DESCRIPTION
When using this library from an ESM module with tsconfig using "Node16" for module/moduleResolution, the types have to more accurately match how the value is exported.

Since the javascript file exports the value with `module.exports = `, this needs to be matched in the definition file. 

This also matches the [requirements](https://github.com/DefinitelyTyped/DefinitelyTyped?tab=readme-ov-file#arethetypeswrongcli-attw-checks) for the DefinitelyTyped project.