### PR TITLE
Improve test setup: grouping, robust paths, coverage, CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# Project conventions
+
+## Tests
+
+Always use explicit `actual` and `expected` variables in tests rather than inlining values directly into assertions. This improves readability.
+
+```js
+// preferred
+const actual = canonicalize(input);
+const expected = '{"a":1}';
+assert.equal(actual, expected);
+
+// avoid
+assert.equal(canonicalize(input), '{"a":1}');
+```

--- a/test/simpletests.js
+++ b/test/simpletests.js
@@ -4,71 +4,103 @@ import canonicalize from '../lib/canonicalize.js';
 
 describe('arrays', () => {
   test('empty array', () => {
-    assert.equal(canonicalize([]), '[]');
+    const actual = canonicalize([]);
+    const expected = '[]';
+    assert.equal(actual, expected);
   });
 
   test('one element array', () => {
-    assert.equal(canonicalize([123]), '[123]');
+    const actual = canonicalize([123]);
+    const expected = '[123]';
+    assert.equal(actual, expected);
   });
 
   test('multi element array', () => {
-    assert.equal(canonicalize([123, 456, 'hello']), '[123,456,"hello"]');
+    const actual = canonicalize([123, 456, 'hello']);
+    const expected = '[123,456,"hello"]';
+    assert.equal(actual, expected);
   });
 
   test('null and undefined values in array', () => {
-    assert.equal(canonicalize([null, undefined, 'hello']), '[null,null,"hello"]');
+    const actual = canonicalize([null, undefined, 'hello']);
+    const expected = '[null,null,"hello"]';
+    assert.equal(actual, expected);
   });
 
   test('object in array', () => {
-    assert.equal(canonicalize([{ b: 123, a: 'string' }]), '[{"a":"string","b":123}]');
+    const actual = canonicalize([{ b: 123, a: 'string' }]);
+    const expected = '[{"a":"string","b":123}]';
+    assert.equal(actual, expected);
   });
 });
 
 describe('objects', () => {
   test('empty object', () => {
-    assert.equal(canonicalize({}), '{}');
+    const actual = canonicalize({});
+    const expected = '{}';
+    assert.equal(actual, expected);
   });
 
   test('object with undefined value', () => {
-    assert.equal(canonicalize({ test: undefined }), '{}');
+    const actual = canonicalize({ test: undefined });
+    const expected = '{}';
+    assert.equal(actual, expected);
   });
 
   test('object with null value', () => {
-    assert.equal(canonicalize({ test: null }), '{"test":null}');
+    const actual = canonicalize({ test: null });
+    const expected = '{"test":null}';
+    assert.equal(actual, expected);
   });
 
   test('object with one property', () => {
-    assert.equal(canonicalize({ hello: 'world' }), '{"hello":"world"}');
+    const actual = canonicalize({ hello: 'world' });
+    const expected = '{"hello":"world"}';
+    assert.equal(actual, expected);
   });
 
   test('object with more than one property', () => {
-    assert.equal(canonicalize({ hello: 'world', number: 123 }), '{"hello":"world","number":123}');
+    const actual = canonicalize({ hello: 'world', number: 123 });
+    const expected = '{"hello":"world","number":123}';
+    assert.equal(actual, expected);
   });
 
   test('object with number key', () => {
-    assert.equal(canonicalize({ 42: 'foo' }), '{"42":"foo"}');
+    const actual = canonicalize({ 42: 'foo' });
+    const expected = '{"42":"foo"}';
+    assert.equal(actual, expected);
   });
 
   test('object with symbol value', () => {
-    assert.equal(canonicalize({ test: Symbol('hello world') }), '{}');
+    const actual = canonicalize({ test: Symbol('hello world') });
+    const expected = '{}';
+    assert.equal(actual, expected);
   });
 
   test('object with symbol key', () => {
-    assert.equal(canonicalize({ [Symbol('hello world')]: 'foo' }), '{}');
+    const actual = canonicalize({ [Symbol('hello world')]: 'foo' });
+    const expected = '{}';
+    assert.equal(actual, expected);
   });
 });
 
 describe('primitive values', () => {
   test('undefined', () => {
-    assert.equal(canonicalize(undefined), undefined);
+    const actual = canonicalize(undefined);
+    const expected = undefined;
+    assert.equal(actual, expected);
   });
 
   test('null', () => {
-    assert.equal(canonicalize(null), 'null');
+    const actual = canonicalize(null);
+    const expected = 'null';
+    assert.equal(actual, expected);
   });
 
   test('symbol', () => {
-    assert.equal(canonicalize(Symbol('hello world')), undefined);
+    const actual = canonicalize(Symbol('hello world'));
+    const expected = undefined;
+    assert.equal(actual, expected);
   });
 });
 
@@ -109,12 +141,16 @@ describe('toJSON', () => {
         return { b: this.b, a: this.a };
       }
     };
-    assert.equal(canonicalize(input), '{"a":123,"b":456}');
+    const actual = canonicalize(input);
+    const expected = '{"a":123,"b":456}';
+    assert.equal(actual, expected);
   });
 
   test('nested object with toJSON is serialized recursively', () => {
     const inner = { toJSON: () => ({ z: 1, a: 2 }) };
-    assert.equal(canonicalize({ x: inner }), '{"x":{"a":2,"z":1}}');
+    const actual = canonicalize({ x: inner });
+    const expected = '{"x":{"a":2,"z":1}}';
+    assert.equal(actual, expected);
   });
 
   test('toJSON returning NaN throws', () => {

--- a/test/simpletests.js
+++ b/test/simpletests.js
@@ -1,152 +1,124 @@
-import { test } from 'node:test';
+import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import canonicalize from '../lib/canonicalize.js';
 
-test('empty array', () => {
-  const input = [];
-  const expected = '[]';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
+describe('arrays', () => {
+  test('empty array', () => {
+    assert.equal(canonicalize([]), '[]');
+  });
+
+  test('one element array', () => {
+    assert.equal(canonicalize([123]), '[123]');
+  });
+
+  test('multi element array', () => {
+    assert.equal(canonicalize([123, 456, 'hello']), '[123,456,"hello"]');
+  });
+
+  test('null and undefined values in array', () => {
+    assert.equal(canonicalize([null, undefined, 'hello']), '[null,null,"hello"]');
+  });
+
+  test('object in array', () => {
+    assert.equal(canonicalize([{ b: 123, a: 'string' }]), '[{"a":"string","b":123}]');
+  });
 });
 
-test('one element array', () => {
-  const input = [123];
-  const expected = '[123]';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
+describe('objects', () => {
+  test('empty object', () => {
+    assert.equal(canonicalize({}), '{}');
+  });
+
+  test('object with undefined value', () => {
+    assert.equal(canonicalize({ test: undefined }), '{}');
+  });
+
+  test('object with null value', () => {
+    assert.equal(canonicalize({ test: null }), '{"test":null}');
+  });
+
+  test('object with one property', () => {
+    assert.equal(canonicalize({ hello: 'world' }), '{"hello":"world"}');
+  });
+
+  test('object with more than one property', () => {
+    assert.equal(canonicalize({ hello: 'world', number: 123 }), '{"hello":"world","number":123}');
+  });
+
+  test('object with number key', () => {
+    assert.equal(canonicalize({ 42: 'foo' }), '{"42":"foo"}');
+  });
+
+  test('object with symbol value', () => {
+    assert.equal(canonicalize({ test: Symbol('hello world') }), '{}');
+  });
+
+  test('object with symbol key', () => {
+    assert.equal(canonicalize({ [Symbol('hello world')]: 'foo' }), '{}');
+  });
 });
 
-test('multi element array', () => {
-  const input = [123, 456, 'hello'];
-  const expected = '[123,456,"hello"]';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
+describe('primitive values', () => {
+  test('undefined', () => {
+    assert.equal(canonicalize(undefined), undefined);
+  });
+
+  test('null', () => {
+    assert.equal(canonicalize(null), 'null');
+  });
+
+  test('symbol', () => {
+    assert.equal(canonicalize(Symbol('hello world')), undefined);
+  });
 });
 
-test('null and undefined values in array', () => {
-  const input = [null, undefined, 'hello'];
-  const expected = '[null,null,"hello"]';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
+describe('NaN handling', () => {
+  test('NaN in array', () => {
+    assert.throws(() => canonicalize([NaN]), { message: 'NaN is not allowed' });
+  });
+
+  test('NaN in object', () => {
+    assert.throws(() => canonicalize({ key: NaN }), { message: 'NaN is not allowed' });
+  });
+
+  test('NaN as top-level value', () => {
+    assert.throws(() => canonicalize(NaN), { message: 'NaN is not allowed' });
+  });
 });
 
-test('NaN in array', () => {
-  assert.throws(() => canonicalize([NaN]), { message: 'NaN is not allowed' });
+describe('Infinity handling', () => {
+  test('Infinity in array', () => {
+    assert.throws(() => canonicalize([Infinity]), { message: 'Infinity is not allowed' });
+  });
+
+  test('Infinity in object', () => {
+    assert.throws(() => canonicalize({ key: Infinity }), { message: 'Infinity is not allowed' });
+  });
+
+  test('-Infinity as top-level value', () => {
+    assert.throws(() => canonicalize(-Infinity), { message: 'Infinity is not allowed' });
+  });
 });
 
-test('NaN in object', () => {
-  assert.throws(() => canonicalize({ key: NaN }), { message: 'NaN is not allowed' });
-});
+describe('toJSON', () => {
+  test('object with toJSON', () => {
+    const input = {
+      a: 123,
+      b: 456,
+      toJSON: function () {
+        return { b: this.b, a: this.a };
+      }
+    };
+    assert.equal(canonicalize(input), '{"a":123,"b":456}');
+  });
 
-test('NaN single value', () => {
-  assert.throws(() => canonicalize(NaN), { message: 'NaN is not allowed' });
-});
+  test('nested object with toJSON is serialized recursively', () => {
+    const inner = { toJSON: () => ({ z: 1, a: 2 }) };
+    assert.equal(canonicalize({ x: inner }), '{"x":{"a":2,"z":1}}');
+  });
 
-test('Infinity in array', () => {
-  assert.throws(() => canonicalize([Infinity]), { message: 'Infinity is not allowed' });
-});
-
-test('Infinity in object', () => {
-  assert.throws(() => canonicalize({ key: Infinity }), { message: 'Infinity is not allowed' });
-});
-
-test('Infinity single value', () => {
-  assert.throws(() => canonicalize(-Infinity), { message: 'Infinity is not allowed' });
-});
-
-test('object in array', () => {
-  const input = [{ b: 123, a: 'string' }];
-  const expected = '[{"a":"string","b":123}]';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
-});
-
-test('empty object', () => {
-  const input = {};
-  const expected = '{}';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
-});
-
-test('object with undefined value', () => {
-  const input = { test: undefined };
-  const expected = '{}';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
-});
-
-test('object with null value', () => {
-  const input = { test: null };
-  const expected = '{"test":null}';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
-});
-
-test('object with one property', () => {
-  const input = { hello: 'world' };
-  const expected = '{"hello":"world"}';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
-});
-
-test('object with more than one property', () => {
-  const input = { hello: 'world', number: 123 };
-  const expected = '{"hello":"world","number":123}';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
-});
-
-test('undefined', () => {
-  const input = undefined;
-  const expected = undefined;
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
-});
-
-test('null', () => {
-  const input = null;
-  const expected = 'null';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
-});
-
-test('symbol', () => {
-  const input = Symbol('hello world');
-  const expected = undefined;
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
-});
-
-test('object with symbol value', () => {
-  const input = { test: Symbol('hello world') };
-  const expected = '{}';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
-});
-
-test('object with number key', () => {
-  const input = { 42: 'foo' };
-  const expected = '{"42":"foo"}';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
-});
-
-test('object with symbol key', () => {
-  const input = { [Symbol('hello world')]: 'foo' };
-  const expected = '{}';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
-});
-
-test('object with toJSON', () => {
-  const input = {
-    a: 123,
-    b: 456,
-    toJSON: function () {
-      return { b: this.b, a: this.a };
-    }
-  };
-  const expected = '{"a":123,"b":456}';
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
+  test('toJSON returning NaN throws', () => {
+    const input = { toJSON: () => NaN };
+    assert.throws(() => canonicalize(input), { message: 'NaN is not allowed' });
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -17,25 +17,30 @@ function testdata(name) {
 
 test('arrays', () => {
   const { input, expected } = testdata('arrays');
-  assert.equal(canonicalize(input), expected);
+  const actual = canonicalize(input);
+  assert.equal(actual, expected);
 });
 
 test('french', () => {
   const { input, expected } = testdata('french');
-  assert.equal(canonicalize(input), expected);
+  const actual = canonicalize(input);
+  assert.equal(actual, expected);
 });
 
 test('structures', () => {
   const { input, expected } = testdata('structures');
-  assert.equal(canonicalize(input), expected);
+  const actual = canonicalize(input);
+  assert.equal(actual, expected);
 });
 
 test('values', () => {
   const { input, expected } = testdata('values');
-  assert.equal(canonicalize(input), expected);
+  const actual = canonicalize(input);
+  assert.equal(actual, expected);
 });
 
 test('weird', () => {
   const { input, expected } = testdata('weird');
-  assert.equal(canonicalize(input), expected);
+  const actual = canonicalize(input);
+  assert.equal(actual, expected);
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,39 +1,41 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import canonicalize from '../lib/canonicalize.js';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const inputDir = join(__dirname, 'testdata/input');
+const outputDir = join(__dirname, 'testdata/output');
+
+function testdata(name) {
+  const input = JSON.parse(readFileSync(join(inputDir, `${name}.json`), 'utf8'));
+  const expected = readFileSync(join(outputDir, `${name}.json`), 'utf8').trim();
+  return { input, expected };
+}
+
 test('arrays', () => {
-  const input = JSON.parse(readFileSync('test/testdata/input/arrays.json', 'utf8'));
-  const expected = readFileSync('test/testdata/output/arrays.json', 'utf8').trim();
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
+  const { input, expected } = testdata('arrays');
+  assert.equal(canonicalize(input), expected);
 });
 
 test('french', () => {
-  const input = JSON.parse(readFileSync('test/testdata/input/french.json', 'utf8'));
-  const expected = readFileSync('test/testdata/output/french.json', 'utf8').trim();
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
+  const { input, expected } = testdata('french');
+  assert.equal(canonicalize(input), expected);
 });
 
 test('structures', () => {
-  const input = JSON.parse(readFileSync('test/testdata/input/structures.json', 'utf8'));
-  const expected = readFileSync('test/testdata/output/structures.json', 'utf8').trim();
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
+  const { input, expected } = testdata('structures');
+  assert.equal(canonicalize(input), expected);
 });
 
 test('values', () => {
-  const input = JSON.parse(readFileSync('test/testdata/input/values.json', 'utf8'));
-  const expected = readFileSync('test/testdata/output/values.json', 'utf8').trim();
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
+  const { input, expected } = testdata('values');
+  assert.equal(canonicalize(input), expected);
 });
 
 test('weird', () => {
-  const input = JSON.parse(readFileSync('test/testdata/input/weird.json', 'utf8'));
-  const expected = readFileSync('test/testdata/output/weird.json', 'utf8').trim();
-  const actual = canonicalize(input);
-  assert.equal(actual, expected);
+  const { input, expected } = testdata('weird');
+  assert.equal(canonicalize(input), expected);
 });


### PR DESCRIPTION
- Use describe() blocks in simpletests.js to group tests by concern
  (arrays, objects, primitives, NaN, Infinity, toJSON)
- Fix CWD-relative readFileSync paths in test.js using import.meta.url
- Add tests for nested toJSON recursion and toJSON returning NaN
- Add Node 24 to CI matrix

https://claude.ai/code/session_01Eejuz8YMPtbRJSa6mhJare