### PR TITLE
Fix circular reference DoS, improve toJSON check, and optimize string building

### DIFF
--- a/bin/canonicalize.js
+++ b/bin/canonicalize.js
@@ -7,6 +7,11 @@ let input = '';
 process.stdin
   .on('data', (data) => { input += data.toString(); })
   .on('end', () => {
-    const output = canonicalize(JSON.parse(input));
-    process.stdout.write(output, 'utf-8');
+    try {
+      const output = canonicalize(JSON.parse(input));
+      process.stdout.write(output, 'utf-8');
+    } catch (e) {
+      process.stderr.write(`Error: ${e.message}\n`);
+      process.exit(1);
+    }
   });

--- a/lib/canonicalize.js
+++ b/lib/canonicalize.js
@@ -1,4 +1,4 @@
-export default function serialize (object) {
+export default function serialize (object, seen = new Set()) {
   if (typeof object === 'number' && isNaN(object)) {
     throw new Error('NaN is not allowed');
   }
@@ -11,26 +11,39 @@ export default function serialize (object) {
     return JSON.stringify(object);
   }
 
-  if (object.toJSON instanceof Function) {
-    return serialize(object.toJSON());
-  }
-
-  if (Array.isArray(object)) {
-    const values = object.reduce((t, cv, ci) => {
-      const comma = ci === 0 ? '' : ',';
-      const value = cv === undefined || typeof cv === 'symbol' ? null : cv;
-      return `${t}${comma}${serialize(value)}`;
-    }, '');
-    return `[${values}]`;
-  }
-
-  const values = Object.keys(object).sort().reduce((t, cv) => {
-    if (object[cv] === undefined ||
-        typeof object[cv] === 'symbol') {
-      return t;
+  if (typeof object.toJSON === 'function') {
+    if (seen.has(object)) {
+      throw new Error('Circular reference detected');
     }
-    const comma = t.length === 0 ? '' : ',';
-    return `${t}${comma}${serialize(cv)}:${serialize(object[cv])}`;
-  }, '');
-  return `{${values}}`;
+    seen.add(object);
+    const result = serialize(object.toJSON(), seen);
+    seen.delete(object);
+    return result;
+  }
+
+  if (seen.has(object)) {
+    throw new Error('Circular reference detected');
+  }
+  seen.add(object);
+
+  let result;
+  if (Array.isArray(object)) {
+    const values = object.map((cv) => {
+      const value = cv === undefined || typeof cv === 'symbol' ? null : cv;
+      return serialize(value, seen);
+    });
+    result = `[${values.join(',')}]`;
+  } else {
+    const parts = [];
+    for (const key of Object.keys(object).sort()) {
+      if (object[key] === undefined || typeof object[key] === 'symbol') {
+        continue;
+      }
+      parts.push(`${serialize(key)}:${serialize(object[key], seen)}`);
+    }
+    result = `{${parts.join(',')}}`;
+  }
+
+  seen.delete(object);
+  return result;
 }

--- a/test/simpletests.js
+++ b/test/simpletests.js
@@ -157,4 +157,38 @@ describe('toJSON', () => {
     const input = { toJSON: () => NaN };
     assert.throws(() => canonicalize(input), { message: 'NaN is not allowed' });
   });
+
+  test('toJSON returning self throws', () => {
+    const input = {};
+    input.toJSON = () => input;
+    assert.throws(() => canonicalize(input), { message: 'Circular reference detected' });
+  });
+});
+
+describe('circular references', () => {
+  test('object referencing itself throws', () => {
+    const input = {};
+    input.self = input;
+    assert.throws(() => canonicalize(input), { message: 'Circular reference detected' });
+  });
+
+  test('array referencing itself throws', () => {
+    const input = [];
+    input.push(input);
+    assert.throws(() => canonicalize(input), { message: 'Circular reference detected' });
+  });
+
+  test('nested circular reference throws', () => {
+    const a = {};
+    const b = { a };
+    a.b = b;
+    assert.throws(() => canonicalize(a), { message: 'Circular reference detected' });
+  });
+
+  test('same object referenced twice (non-circular) is allowed', () => {
+    const shared = { z: 1 };
+    const actual = canonicalize({ x: shared, y: shared });
+    const expected = '{"x":{"z":1},"y":{"z":1}}';
+    assert.equal(actual, expected);
+  });
 });


### PR DESCRIPTION
- Add circular reference detection using a Set to prevent infinite
  recursion / stack overflow (DoS vulnerability) on cyclic objects and arrays.
  The same object can still appear at multiple non-cyclic paths.
- Replace `instanceof Function` with `typeof === 'function'` for the
  toJSON check, which is more robust across VM realms.
- Replace string concatenation in reduce with array + join for O(n)
  instead of O(n²) memory allocation on large inputs.
- Add try/catch in bin/canonicalize.js so parse/serialize errors produce
  a clean stderr message and non-zero exit code instead of a raw stack trace.
- Add tests covering all new behaviour.

https://claude.ai/code/session_011TuCWeHLaGbHeJYHTLoaqT