### PR TITLE
Consistency fixes: rename serialize to canonicalize, use expected variables in throws tests

### DIFF
--- a/lib/canonicalize.js
+++ b/lib/canonicalize.js
@@ -1,4 +1,4 @@
-export default function serialize (object, seen = new Set()) {
+export default function canonicalize (object, seen = new Set()) {
   if (typeof object === 'number' && isNaN(object)) {
     throw new Error('NaN is not allowed');
   }
@@ -16,7 +16,7 @@ export default function serialize (object, seen = new Set()) {
       throw new Error('Circular reference detected');
     }
     seen.add(object);
-    const result = serialize(object.toJSON(), seen);
+    const result = canonicalize(object.toJSON(), seen);
     seen.delete(object);
     return result;
   }
@@ -30,7 +30,7 @@ export default function serialize (object, seen = new Set()) {
   if (Array.isArray(object)) {
     const values = object.map((cv) => {
       const value = cv === undefined || typeof cv === 'symbol' ? null : cv;
-      return serialize(value, seen);
+      return canonicalize(value, seen);
     });
     result = `[${values.join(',')}]`;
   } else {
@@ -39,7 +39,7 @@ export default function serialize (object, seen = new Set()) {
       if (object[key] === undefined || typeof object[key] === 'symbol') {
         continue;
       }
-      parts.push(`${serialize(key)}:${serialize(object[key], seen)}`);
+      parts.push(`${canonicalize(key)}:${canonicalize(object[key], seen)}`);
     }
     result = `{${parts.join(',')}}`;
   }

--- a/test/simpletests.js
+++ b/test/simpletests.js
@@ -106,29 +106,35 @@ describe('primitive values', () => {
 
 describe('NaN handling', () => {
   test('NaN in array', () => {
-    assert.throws(() => canonicalize([NaN]), { message: 'NaN is not allowed' });
+    const expected = { message: 'NaN is not allowed' };
+    assert.throws(() => canonicalize([NaN]), expected);
   });
 
   test('NaN in object', () => {
-    assert.throws(() => canonicalize({ key: NaN }), { message: 'NaN is not allowed' });
+    const expected = { message: 'NaN is not allowed' };
+    assert.throws(() => canonicalize({ key: NaN }), expected);
   });
 
   test('NaN as top-level value', () => {
-    assert.throws(() => canonicalize(NaN), { message: 'NaN is not allowed' });
+    const expected = { message: 'NaN is not allowed' };
+    assert.throws(() => canonicalize(NaN), expected);
   });
 });
 
 describe('Infinity handling', () => {
   test('Infinity in array', () => {
-    assert.throws(() => canonicalize([Infinity]), { message: 'Infinity is not allowed' });
+    const expected = { message: 'Infinity is not allowed' };
+    assert.throws(() => canonicalize([Infinity]), expected);
   });
 
   test('Infinity in object', () => {
-    assert.throws(() => canonicalize({ key: Infinity }), { message: 'Infinity is not allowed' });
+    const expected = { message: 'Infinity is not allowed' };
+    assert.throws(() => canonicalize({ key: Infinity }), expected);
   });
 
   test('-Infinity as top-level value', () => {
-    assert.throws(() => canonicalize(-Infinity), { message: 'Infinity is not allowed' });
+    const expected = { message: 'Infinity is not allowed' };
+    assert.throws(() => canonicalize(-Infinity), expected);
   });
 });
 
@@ -155,13 +161,15 @@ describe('toJSON', () => {
 
   test('toJSON returning NaN throws', () => {
     const input = { toJSON: () => NaN };
-    assert.throws(() => canonicalize(input), { message: 'NaN is not allowed' });
+    const expected = { message: 'NaN is not allowed' };
+    assert.throws(() => canonicalize(input), expected);
   });
 
   test('toJSON returning self throws', () => {
     const input = {};
     input.toJSON = () => input;
-    assert.throws(() => canonicalize(input), { message: 'Circular reference detected' });
+    const expected = { message: 'Circular reference detected' };
+    assert.throws(() => canonicalize(input), expected);
   });
 });
 
@@ -169,20 +177,23 @@ describe('circular references', () => {
   test('object referencing itself throws', () => {
     const input = {};
     input.self = input;
-    assert.throws(() => canonicalize(input), { message: 'Circular reference detected' });
+    const expected = { message: 'Circular reference detected' };
+    assert.throws(() => canonicalize(input), expected);
   });
 
   test('array referencing itself throws', () => {
     const input = [];
     input.push(input);
-    assert.throws(() => canonicalize(input), { message: 'Circular reference detected' });
+    const expected = { message: 'Circular reference detected' };
+    assert.throws(() => canonicalize(input), expected);
   });
 
   test('nested circular reference throws', () => {
     const a = {};
     const b = { a };
     a.b = b;
-    assert.throws(() => canonicalize(a), { message: 'Circular reference detected' });
+    const expected = { message: 'Circular reference detected' };
+    assert.throws(() => canonicalize(a), expected);
   });
 
   test('same object referenced twice (non-circular) is allowed', () => {


### PR DESCRIPTION
- Rename internal function from `serialize` to `canonicalize` to match the module name, export, and binary
- Add explicit `expected` variables in all `assert.throws` calls in simpletests.js per CLAUDE.md convention