### PR TITLE
Reject lone Unicode surrogates

### DIFF
--- a/lib/canonicalize.js
+++ b/lib/canonicalize.js
@@ -1,3 +1,21 @@
+function hasLoneSurrogate (value) {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+
+    if (code >= 0xD800 && code <= 0xDBFF) {
+      const next = value.charCodeAt(i + 1);
+      if (!(next >= 0xDC00 && next <= 0xDFFF)) {
+        return true;
+      }
+      i++;
+    } else if (code >= 0xDC00 && code <= 0xDFFF) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export default function canonicalize (object, seen = new Set()) {
   if (typeof object === 'number' && isNaN(object)) {
     throw new Error('NaN is not allowed');
@@ -5,6 +23,10 @@ export default function canonicalize (object, seen = new Set()) {
 
   if (typeof object === 'number' && !isFinite(object)) {
     throw new Error('Infinity is not allowed');
+  }
+
+  if (typeof object === 'string' && hasLoneSurrogate(object)) {
+    throw new Error('Lone surrogate is not allowed');
   }
 
   if (object === null || typeof object !== 'object') {

--- a/lib/canonicalize.js
+++ b/lib/canonicalize.js
@@ -3,6 +3,9 @@ function hasLoneSurrogate (value) {
     const code = value.charCodeAt(i);
 
     if (code >= 0xD800 && code <= 0xDBFF) {
+      if (i === value.length - 1) {
+        return true;
+      }
       const next = value.charCodeAt(i + 1);
       if (!(next >= 0xDC00 && next <= 0xDFFF)) {
         return true;

--- a/test/simpletests.js
+++ b/test/simpletests.js
@@ -138,6 +138,33 @@ describe('Infinity handling', () => {
   });
 });
 
+describe('Unicode handling', () => {
+  test('lone high surrogate in value throws', () => {
+    const input = { key: '\uD800' };
+    const expected = { message: 'Lone surrogate is not allowed' };
+    assert.throws(() => canonicalize(input), expected);
+  });
+
+  test('lone low surrogate in value throws', () => {
+    const input = { key: '\uDEAD' };
+    const expected = { message: 'Lone surrogate is not allowed' };
+    assert.throws(() => canonicalize(input), expected);
+  });
+
+  test('lone surrogate in object key throws', () => {
+    const input = { ['\uD800']: 'value' };
+    const expected = { message: 'Lone surrogate is not allowed' };
+    assert.throws(() => canonicalize(input), expected);
+  });
+
+  test('valid surrogate pair is allowed', () => {
+    const input = { key: '\uD83D\uDE00' };
+    const actual = canonicalize(input);
+    const expected = '{"key":"😀"}';
+    assert.equal(actual, expected);
+  });
+});
+
 describe('toJSON', () => {
   test('object with toJSON', () => {
     const input = {

--- a/test/simpletests.js
+++ b/test/simpletests.js
@@ -151,6 +151,12 @@ describe('Unicode handling', () => {
     assert.throws(() => canonicalize(input), expected);
   });
 
+  test('lone high surrogate before a non-low-surrogate throws', () => {
+    const input = { key: '\uD800a' };
+    const expected = { message: 'Lone surrogate is not allowed' };
+    assert.throws(() => canonicalize(input), expected);
+  });
+
   test('lone surrogate in object key throws', () => {
     const input = { ['\uD800']: 'value' };
     const expected = { message: 'Lone surrogate is not allowed' };


### PR DESCRIPTION
Closes #23.

RFC 8785 requires implementations to terminate when input contains invalid Unicode data such as an unpaired surrogate. Since well-formed `JSON.stringify` escapes lone surrogates instead of rejecting them, the existing primitive serialization path emitted canonical output for invalid input.

This change adds a Node 18-compatible UTF-16 scan before string serialization. It rejects lone high and low surrogates in both values and object member names while continuing to accept valid surrogate pairs.

Validation:

- `npm test` — 39/39 pass
- `npm run lint` — pass
- `npm run coverage` — 100% statements, branches, functions, and lines
- `git diff --check` — pass
