### PR TITLE
Bump minimum Node.js to 22 and use isWellFormed()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22, 24]
+        node-version: [22, 24, 26]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/lib/canonicalize.js
+++ b/lib/canonicalize.js
@@ -1,24 +1,3 @@
-function hasLoneSurrogate (value) {
-  for (let i = 0; i < value.length; i++) {
-    const code = value.charCodeAt(i);
-
-    if (code >= 0xD800 && code <= 0xDBFF) {
-      if (i === value.length - 1) {
-        return true;
-      }
-      const next = value.charCodeAt(i + 1);
-      if (!(next >= 0xDC00 && next <= 0xDFFF)) {
-        return true;
-      }
-      i++;
-    } else if (code >= 0xDC00 && code <= 0xDFFF) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 export default function canonicalize (object, seen = new Set()) {
   if (typeof object === 'number' && isNaN(object)) {
     throw new Error('NaN is not allowed');
@@ -28,7 +7,7 @@ export default function canonicalize (object, seen = new Set()) {
     throw new Error('Infinity is not allowed');
   }
 
-  if (typeof object === 'string' && hasLoneSurrogate(object)) {
+  if (typeof object === 'string' && !object.isWellFormed()) {
     throw new Error('Lone surrogate is not allowed');
   }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bin/"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- Drop Node.js 18 and 20 (both end-of-life), set minimum to `>=22`
- Replace manual `hasLoneSurrogate` function with built-in `String.prototype.isWellFormed()`
- Update CI matrix to test against Node.js 22, 24, and 26

## Test plan
- [x] All 40 existing tests pass
- [x] CI passes on Node.js 22, 24, and 26

🤖 Generated with [Claude Code](https://claude.com/claude-code)